### PR TITLE
Migrates use of Optional to java.util

### DIFF
--- a/src/main/java/nl/knaw/huygens/pergamon/nlp/langident/service/LangIdentResource.java
+++ b/src/main/java/nl/knaw/huygens/pergamon/nlp/langident/service/LangIdentResource.java
@@ -23,7 +23,6 @@ package nl.knaw.huygens.pergamon.nlp.langident.service;
  */
 
 import com.codahale.metrics.annotation.Timed;
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import nl.knaw.huygens.pergamon.nlp.langident.Model;
 
@@ -37,6 +36,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import java.util.Map;
+import java.util.Optional;
 
 import static java.lang.String.format;
 
@@ -58,7 +58,7 @@ public class LangIdentResource {
   @Timed
   public Map<String, Object> classify(@FormParam("text") String text,
                                       @QueryParam("model") Optional<String> modelName) {
-    String name = modelName.or(defaultModel);
+    String name = modelName.orElse(defaultModel);
     Model model = modelByName(name);
     return ImmutableMap.of(
       "model", name,
@@ -71,7 +71,7 @@ public class LangIdentResource {
   @Timed
   @Path("/languages")
   public Map<String, Object> listLanguages(@QueryParam("model") Optional<String> modelName) {
-    String name = modelName.or(defaultModel);
+    String name = modelName.orElse(defaultModel);
     Model model = modelByName(name);
     return ImmutableMap.of(
       "languages", model.languages(),

--- a/src/main/java/nl/knaw/huygens/pergamon/nlp/langident/service/health/ModelHealthCheck.java
+++ b/src/main/java/nl/knaw/huygens/pergamon/nlp/langident/service/health/ModelHealthCheck.java
@@ -23,9 +23,9 @@ package nl.knaw.huygens.pergamon.nlp.langident.service.health;
  */
 
 import com.codahale.metrics.health.HealthCheck;
-import com.google.common.base.Optional;
 import nl.knaw.huygens.pergamon.nlp.langident.service.LangIdentResource;
 
+import java.util.Optional;
 import java.util.Set;
 
 public class ModelHealthCheck extends HealthCheck {

--- a/src/test/java/nl/knaw/huygens/pergamon/nlp/langident/service/LangIdentResourceTest.java
+++ b/src/test/java/nl/knaw/huygens/pergamon/nlp/langident/service/LangIdentResourceTest.java
@@ -22,11 +22,11 @@ package nl.knaw.huygens.pergamon.nlp.langident.service;
  * #L%
  */
 
-import com.google.common.base.Optional;
 import org.junit.Test;
 
 import javax.ws.rs.WebApplicationException;
 import java.util.HashMap;
+import java.util.Optional;
 
 public class LangIdentResourceTest {
   @Test(expected = WebApplicationException.class)


### PR DESCRIPTION
Since Dropwizard 1.0.0. we no longer have to depend on Guava's Optional.

https://github.com/dropwizard/dropwizard/wiki/Upgrade-guide-0.9.x-to-1.0.x#replace-guavas-optional-by-javautiloptional-in-dropwizard-public-api