### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Langident
 =========
 
-[![Docker Automated build](https://img.shields.io/docker/automated/huygensing/langident.svg)](https://hub.docker.com/r/huygensing/langident)
+[![Docker Automated build](https://img.shields.io/docker/automated/huygensing/langident.svg)](https://hub.docker.com/r/huygensing/langident) [![](https://images.microbadger.com/badges/image/huygensing/langident.svg)](https://microbadger.com/images/huygensing/langident "Get your own image badge on microbadger.com")
 
 This is a language guesser for historical text. It distinguishes between
 German, English, French, Latin and Dutch (that is, the seventeenth-century
@@ -85,3 +85,4 @@ To use a different model, pass it as a GET parameter:
 The list of known languages is available from the /ident/languages endpoint:
 
     curl http://localhost:8080/ident/languages?model=cavnartrenkle
+ 


### PR DESCRIPTION
We saw your image on Docker Hub at [huygensing/langident](https://hub.docker.com/r/huygensing/langident/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/huygensing/langident).

As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/huygensing/langident.svg)](https://microbadger.com/images/huygensing/langident)
